### PR TITLE
ecs - custom table columns and stat card

### DIFF
--- a/frontend/components/Item/View/Table.vue
+++ b/frontend/components/Item/View/Table.vue
@@ -49,12 +49,17 @@
                 {{ d.name }}
               </NuxtLink>
             </template>
-            <template v-else-if="cell(h) === 'cell-purchasePrice'">
-              <Currency :amount="d.purchasePrice" />
+            <template v-else-if="cell(h) === 'cell-location'">
+              <NuxtLink
+                v-if="d.location"
+                class="text-sm hover:link badge shadow-md rounded-md"
+                :to="`/location/${d.location.id}`"
+              >
+                {{ d.location.name }}
+              </NuxtLink>
             </template>
-            <template v-else-if="cell(h) === 'cell-insured'">
-              <MdiCheck v-if="d.insured" class="text-green-500 h-5 w-5 inline" />
-              <MdiClose v-else class="text-red-500 h-5 w-5 inline" />
+            <template v-else-if="cell(h) === 'cell-labels'">
+              <LabelChip v-for="label in d.labels" :key="label.id" :label="label" size="sm" />
             </template>
             <slot v-else :name="cell(h)" v-bind="{ item: d }">
               {{ extractValue(d, h.value) }}
@@ -78,8 +83,6 @@
   import type { ItemSummary } from "~~/lib/api/types/data-contracts";
   import MdiArrowDown from "~icons/mdi/arrow-down";
   import MdiArrowUp from "~icons/mdi/arrow-up";
-  import MdiCheck from "~icons/mdi/check";
-  import MdiClose from "~icons/mdi/close";
 
   type Props = {
     items: ItemSummary[];
@@ -92,8 +95,10 @@
     return [
       { text: "Name", value: "name" },
       { text: "Quantity", value: "quantity", align: "center" },
-      { text: "Insured", value: "insured", align: "center" },
-      { text: "Price", value: "purchasePrice" },
+      { text: "Labels", value: "labels", align: "center" },
+      { text: "Location", value: "location" },
+      // { text: "Insured", value: "insured", align: "center" },
+      // { text: "Price", value: "purchasePrice" },
     ] as TableHeader[];
   });
 

--- a/frontend/composables/use-preferences.ts
+++ b/frontend/composables/use-preferences.ts
@@ -6,6 +6,7 @@ export type ViewType = "table" | "card" | "tree";
 export type LocationViewPreferences = {
   showDetails: boolean;
   showEmpty: boolean;
+  showPrices: boolean;
   editorAdvancedView: boolean;
   itemDisplayView: ViewType;
   theme: DaisyTheme;
@@ -21,6 +22,7 @@ export function useViewPreferences(): Ref<LocationViewPreferences> {
     {
       showDetails: true,
       showEmpty: true,
+      showPrices: false,
       editorAdvancedView: false,
       itemDisplayView: "card",
       theme: "homebox",

--- a/frontend/pages/home/statistics.ts
+++ b/frontend/pages/home/statistics.ts
@@ -15,9 +15,9 @@ export function statCardData(api: UserClient) {
   return computed(() => {
     return [
       {
-        label: "Total Value",
-        value: statistics.value?.totalItemPrice || 0,
-        type: "currency",
+        label: "ecs.lan",
+        value: "homebox",
+        type: "number",
       },
       {
         label: "Total Items",

--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -174,7 +174,7 @@
       },
       {
         name: "Insured",
-        text: item.value?.insured ? "Yes" : "No",
+        text: item.value?.insured ? "Yes" : "",
       },
       {
         name: "Notes",

--- a/frontend/pages/label/[id].vue
+++ b/frontend/pages/label/[id].vue
@@ -10,6 +10,7 @@
   const route = useRoute();
   const api = useUserApi();
   const toast = useNotifier();
+  const preferences = useViewPreferences();
 
   const labelId = computed<string>(() => route.params.id as string);
 
@@ -88,7 +89,7 @@
       return [];
     }
 
-    return resp.data;
+    return resp.data.items;
   });
 </script>
 
@@ -118,12 +119,19 @@
               <h1 class="text-2xl pb-1 flex items-center gap-3">
                 {{ label ? label.name : "" }}
 
-                <div
-                  v-if="items && items.totalPrice"
-                  class="text-xs bg-secondary text-secondary-content rounded-full px-2 py-1"
-                >
+                <div v-if="items && items.length > 0">
                   <div>
-                    <Currency :amount="items.totalPrice" />
+                    <span class="text-xs text-gray-500">
+                      {{ items.length }} item{{ items.length > 1 ? "s" : "" }}
+                    </span>
+                  </div>
+                </div>
+
+                <div v-if="preferences.showPrices" class="flex">
+                  <div v-if="items && items.reduce((acc, item) => acc + Number(item.purchasePrice), 0) > 0">
+                    <div>
+                      <Currency :amount="items.reduce((acc, item) => acc + Number(item.purchasePrice), 0)" />
+                    </div>
                   </div>
                 </div>
               </h1>
@@ -146,6 +154,11 @@
                 <MdiDelete class="mr-2" />
                 Delete
               </BaseButton>
+              <BaseButton class="btn btn-sm">
+                <div class="mr-auto tooltip tooltip-top" data-tip="Show Prices">
+                  <input v-model="preferences.showPrices" type="checkbox" class="toggle toggle-primary" />
+                </div>
+              </BaseButton>
             </div>
           </div>
         </header>
@@ -153,7 +166,7 @@
         <Markdown v-if="label && label.description" class="text-base" :source="label.description"> </Markdown>
       </div>
       <section v-if="label && items">
-        <ItemViewSelectable :items="items.items" />
+        <ItemViewSelectable :items="items" />
       </section>
     </BaseContainer>
   </BaseContainer>


### PR DESCRIPTION
I don't care about seeing the "Price" and "Insured" values in the summary page so I changed them.


![Homebox _ Home](https://github.com/user-attachments/assets/a619d609-103d-42c0-a9f6-0d70bf2c74bd)



custom docker-compose i'm using to build and run this

```
volumes:
  homebox_data:
    driver: local

networks:
  default:
      name: proxy-tsnet
      external: true

services:
  homebox:
    image: ecshreve/homebox-dev:latest
    container_name: homebox
    build:
      context: .
      dockerfile: ./Dockerfile
      args:
        - COMMIT=head
        - BUILD_TIME=0001-01-01T00:00:00Z
    volumes:
      - homebox_data:/data
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.homebox.rule=Host(`homebox.lan`)"
      - "traefik.http.routers.homebox.entrypoints=web"
      - "traefik.http.services.homebox.loadbalancer.server.port=7745"
   ```